### PR TITLE
Add expanded and fontSize properties

### DIFF
--- a/lib/src/flutter_syntax_view.dart
+++ b/lib/src/flutter_syntax_view.dart
@@ -10,6 +10,7 @@ class SyntaxView extends StatefulWidget {
     this.withZoom,
     this.withLinesCount,
     this.fontSize = 12.0,
+    this.expanded = false,
   });
 
   final String code;
@@ -18,6 +19,7 @@ class SyntaxView extends StatefulWidget {
   final bool withLinesCount;
   final SyntaxTheme syntaxTheme;
   final double fontSize;
+  final bool expanded;
 
   @override
   State<StatefulWidget> createState() => SyntaxViewState();
@@ -75,7 +77,7 @@ class SyntaxViewState extends State<SyntaxView> {
               ? EdgeInsets.only(left: 5, top: 10, right: 10, bottom: 10)
               : EdgeInsets.all(10),
           color: (widget.syntaxTheme ?? SyntaxTheme.dracula()).backgroundColor,
-          constraints: BoxConstraints.expand(),
+          constraints: widget.expanded ? BoxConstraints.expand() : null,
           child: Scrollbar(
               child: SingleChildScrollView(
                   child: SingleChildScrollView(

--- a/lib/src/flutter_syntax_view.dart
+++ b/lib/src/flutter_syntax_view.dart
@@ -3,26 +3,35 @@ import 'package:flutter/material.dart';
 import 'syntax/index.dart';
 
 class SyntaxView extends StatefulWidget {
-  SyntaxView(
-      {@required this.code,
-      @required this.syntax,
-      this.syntaxTheme,
-      this.withZoom,
-      this.withLinesCount});
+  SyntaxView({
+    @required this.code,
+    @required this.syntax,
+    this.syntaxTheme,
+    this.withZoom,
+    this.withLinesCount,
+    this.fontSize = 12.0,
+  });
 
   final String code;
   final Syntax syntax;
   final bool withZoom;
   final bool withLinesCount;
   final SyntaxTheme syntaxTheme;
+  final double fontSize;
 
   @override
   State<StatefulWidget> createState() => SyntaxViewState();
 }
 
 class SyntaxViewState extends State<SyntaxView> {
+  @override
+  void initState() {
+    super.initState();
+    _fontSize = widget.fontSize;
+  }
+
   /// Zoom Controls
-  double _fontSize = 12.0;
+  double _fontSize;
   final double _baseFontSize = 12.0;
   double _fontScale = 1.0;
   double _baseFontScale = 1.0;
@@ -122,7 +131,7 @@ class SyntaxViewState extends State<SyntaxView> {
     return RichText(
       textScaleFactor: _baseFontScale,
       text: TextSpan(
-        style: TextStyle(fontFamily: 'monospace', fontSize: 12.0),
+        style: TextStyle(fontFamily: 'monospace', fontSize: _fontSize),
         children: <TextSpan>[
           getSyntax(widget.syntax, widget.syntaxTheme).format(widget.code)
         ],


### PR DESCRIPTION
Hello @BaderEddineOuaich,

I'd like to share the two properties I needed to add to the package while working on my app:
- `fontSize` with a default value of `12.0` like in the current implementation.
- `expanded` (default to `false`) which allows the `SyntaxView` to be used inside a `Column` or a `ListView`...
   When the property's value is `true`, the widget behaves like in the current implementation. This would be a breaking change.

What do you think about the changes?

Cheers